### PR TITLE
Support for termination of iteration in iter callback

### DIFF
--- a/objecttree_test.go
+++ b/objecttree_test.go
@@ -160,7 +160,7 @@ func TestObjectTree(t *testing.T) {
 	// test Do
 
 	x := ""
-	tree.Do(func(z interface{}) { x += z.(MyObject).Key })
+	tree.Do(func(z interface{}) bool { x += z.(MyObject).Key; return true })
 
 	if x != "barfoofoo" {
 		t.Errorf("Do function did not concat values correctly, expected barfoofoo: %d\n", x)
@@ -234,13 +234,14 @@ func TestObjectTree(t *testing.T) {
 	prev = ""
 
 	// make sure elements sorted
-	tree.Do(func(elem interface{}) {
+	tree.Do(func(elem interface{}) bool {
 		var cur string
 		cur = elem.(MyObject).Key
 		if prev > cur {
 			t.Errorf("Elements not in order, previous = %d, current = %d\n", prev, cur)
 		}
 		prev = cur
+		return true
 	})
 
 }

--- a/pairtree.go
+++ b/pairtree.go
@@ -26,7 +26,7 @@ func (a Pair) Compare(b Interface) int {
 }
 
 // Iterate function
-type PairIterateFunc func(v Pair)
+type PairIterateFunc func(v Pair) bool
 
 // Initialize or reset a StringTree
 func (t *PairTree) Init(flags byte) *PairTree {
@@ -60,12 +60,14 @@ func (t *PairTree) Find(key string) *Pair {
 
 // Do calls function f for each element of the tree, in order.
 // The function should not change the structure of the tree underfoot.
-func (t *PairTree) Do(f PairIterateFunc) { t.ObjectTree.Do(func(v interface{}) { f(v.(Pair)) }) }
+func (t *PairTree) Do(f PairIterateFunc) {
+	t.ObjectTree.Do(func(v interface{}) bool { return f(v.(Pair)) })
+}
 
 // chanIterate should be used as a goroutine to produce all the values
 // in the tree.
 func (t *PairTree) chanIterate(c chan<- Pair) {
-	t.Do(func(v Pair) { c <- v })
+	t.Do(func(v Pair) bool { c <- v; return true })
 	close(c)
 }
 
@@ -81,9 +83,10 @@ func (t *PairTree) Data() []Pair {
 	arr := make([]Pair, t.Len())
 	var i int
 	i = 0
-	t.Do(func(v Pair) {
+	t.Do(func(v Pair) bool {
 		arr[i] = v
 		i++
+		return true
 	})
 	return arr
 }
@@ -123,5 +126,5 @@ func (t *PairTree) RemoveAt(index int) *Pair {
 
 // Print the values in the tree
 func (t *PairTree) Print(w io.Writer, f PairIterateFunc, itemSiz int) {
-	t.ObjectTree.Print(w, func(v interface{}) { f(v.(Pair)) }, itemSiz)
+	t.ObjectTree.Print(w, func(v interface{}) bool { return f(v.(Pair)) }, itemSiz)
 }

--- a/pairtree_test.go
+++ b/pairtree_test.go
@@ -145,7 +145,7 @@ func TestPairTree(t *testing.T) {
 	// test Do
 
 	x := ""
-	tree.Do(func(z Pair) { x += z.Key })
+	tree.Do(func(z Pair) bool { x += z.Key; return true })
 
 	if x != "barfoofoo" {
 		t.Errorf("Do function did not concat values correctly, expected barfoofoo: %d\n", x)
@@ -219,13 +219,14 @@ func TestPairTree(t *testing.T) {
 	prev = ""
 
 	// make sure elements sorted
-	tree.Do(func(elem Pair) {
+	tree.Do(func(elem Pair) bool {
 		var cur string
 		cur = elem.Key
 		if prev > cur {
 			t.Errorf("Elements not in order, previous = %d, current = %d\n", prev, cur)
 		}
 		prev = cur
+		return true
 	})
 
 }

--- a/stringtree.go
+++ b/stringtree.go
@@ -19,7 +19,7 @@ func stringCompare(s1 interface{}, s2 interface{}) int {
 }
 
 // Iterate function
-type StringIterateFunc func(v string)
+type StringIterateFunc func(v string) bool
 
 // Initialize or reset a StringTree
 func (t *StringTree) Init(flags byte) *StringTree {
@@ -51,12 +51,14 @@ func (t *StringTree) Find(key string) string {
 
 // Do calls function f for each element of the tree, in order.
 // The function should not change the structure of the tree underfoot.
-func (t *StringTree) Do(f StringIterateFunc) { t.Tree.Do(func(v interface{}) { f(v.(string)) }) }
+func (t *StringTree) Do(f StringIterateFunc) {
+	t.Tree.Do(func(v interface{}) bool { return f(v.(string)) })
+}
 
 // chanIterate should be used as a goroutine to produce all the values
 // in the tree.
 func (t *StringTree) chanIterate(c chan<- string) {
-	t.Do(func(v string) { c <- v })
+	t.Do(func(v string) bool { c <- v; return true })
 	close(c)
 }
 
@@ -72,9 +74,10 @@ func (t *StringTree) Data() []string {
 	arr := make([]string, t.Len())
 	var i int
 	i = 0
-	t.Do(func(v string) {
+	t.Do(func(v string) bool {
 		arr[i] = v
 		i++
+		return true
 	})
 	return arr
 }
@@ -110,5 +113,5 @@ func (t *StringTree) RemoveAt(index int) string {
 }
 
 func (t *StringTree) Print(w io.Writer, f StringIterateFunc, itemSiz int) {
-	t.Tree.Print(w, func(v interface{}) { f(v.(string)) }, itemSiz)
+	t.Tree.Print(w, func(v interface{}) bool { return f(v.(string)) }, itemSiz)
 }

--- a/stringtree_test.go
+++ b/stringtree_test.go
@@ -150,7 +150,7 @@ func TestStringTree(t *testing.T) {
 	// test Do
 
 	x := ""
-	tree.Do(func(z string) { x += z })
+	tree.Do(func(z string) bool { x += z; return true })
 
 	if x != "141415" {
 		t.Errorf("Do function did not concatvalues correctly, expected 141415: %d\n", x)
@@ -224,13 +224,14 @@ func TestStringTree(t *testing.T) {
 	prev = ""
 
 	// make sure elements sorted
-	tree.Do(func(elem string) {
+	tree.Do(func(elem string) bool {
 		var cur string
 		cur = elem
 		if prev > cur {
 			t.Errorf("Elements not in order, previous = %d, current = %d\n", prev, cur)
 		}
 		prev = cur
+		return true
 	})
 
 }

--- a/tree.go
+++ b/tree.go
@@ -38,7 +38,7 @@ const (
 type CompareFunc func(v1 interface{}, v2 interface{}) int
 
 // Iterate function
-type IterateFunc func(v interface{})
+type IterateFunc func(v interface{}) bool
 
 // Tree object
 type Tree struct {
@@ -201,17 +201,29 @@ type iterData struct {
 
 // iterate recursively traverses the tree and executes
 // the iteration function
-func (d *iterData) iterate(node *treeNode) {
+func (d *iterData) iterate(node *treeNode) bool {
+	var proceed bool
 
 	if node.left != nil {
-		d.iterate(node.left)
+		proceed = d.iterate(node.left)
+		if !proceed {
+			return false
+		}
 	}
 
-	d.iter(node.value)
+	proceed = d.iter(node.value)
+	if !proceed {
+		return false
+	}
 
 	if node.right != nil {
-		d.iterate(node.right)
+		proceed = d.iterate(node.right)
+		if !proceed {
+			return false
+		}
 	}
+
+	return true
 }
 
 // Do calls function f for each element of the tree, in order.
@@ -227,7 +239,7 @@ func (t *Tree) Do(f IterateFunc) {
 // chanIterate should be used as a goroutine to produce all the values
 // in the tree.
 func (t *Tree) chanIterate(c chan<- interface{}) {
-	t.Do(func(v interface{}) { c <- v })
+	t.Do(func(v interface{}) bool { c <- v; return true })
 	close(c)
 }
 
@@ -243,9 +255,10 @@ func (t *Tree) Data() []interface{} {
 	arr := make([]interface{}, t.Len())
 	var i int
 	i = 0
-	t.Do(func(v interface{}) {
+	t.Do(func(v interface{}) bool {
 		arr[i] = v
 		i++
+		return true
 	})
 	return arr
 }

--- a/tree_test.go
+++ b/tree_test.go
@@ -159,7 +159,7 @@ func TestTree(t *testing.T) {
 	// test Do
 
 	x := 0
-	tree.Do(func(z interface{}) { x += z.(int) })
+	tree.Do(func(z interface{}) bool { x += z.(int); return true })
 
 	if x != 43 {
 		t.Errorf("Do function did not add up values correctly, expected 43: %d\n", x)
@@ -233,13 +233,14 @@ func TestTree(t *testing.T) {
 	prev = -1
 
 	// make sure elements sorted
-	tree.Do(func(elem interface{}) {
+	tree.Do(func(elem interface{}) bool {
 		var cur int
 		cur = elem.(int)
 		if prev > cur {
 			t.Errorf("Elements not in order, previous = %d, current = %d\n", prev, cur)
 		}
 		prev = cur
+		return true
 	})
 
 }


### PR DESCRIPTION
Currently an iteration in progress cannot be terminated midway which is a handicap in some scenarios. This patch achieves this ability by letting the callback return a boolean value that tells the iterator if the iteration can be continued.
